### PR TITLE
Update branch-alias to 2.x-dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     "extra": {
         "project-files": [],
         "branch-alias": {
-            "dev-master": "1.x-dev"
+            "dev-master": "2.x-dev"
         }
     },
     "config": {


### PR DESCRIPTION
Update branch-alias to 2.x-dev so that requiring `1.x-dev` installs `1.x-dev` rather than `dev-master`