### PR TITLE
DEP Use v3 of silverstripe-composer-update-checker

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         "silverstripe/securityreport": "2.x-dev",
         "silverstripe/sitewidecontent-report": "3.x-dev",
         "bringyourownideas/silverstripe-maintenance": "2.x-dev",
-        "bringyourownideas/silverstripe-composer-update-checker": "2.x-dev"
+        "bringyourownideas/silverstripe-composer-update-checker": "3.x-dev"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5"


### PR DESCRIPTION
Issue https://github.com/silverstripe/silverstripe-framework/issues/10250

Relates to https://github.com/bringyourownideas/silverstripe-composer-update-checker/pull/62

Travis build is failing because we need to tag a new major of silverstripe-composer-update-checker to make things installable